### PR TITLE
Disable on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `AdvancedPageCache` is a powerful static page cache type plugin that caches the entire page output to the Grav cache and reuses this when the URL path is requested again.  This can dramatically increase the performance of a Grav site.  Due to the static nature of this cache, if enabled, you will need to **manually** clear the cache if you make any page modifications.  This cache plugin (by default) will not cache pages that have URLs that contain either **querystring or grav-paramater** style values, you may want to disable this behavior.
 
-This plugin can provide dramatic performance boosts and is an ideal solution for sites with many pages and predominantely static content.
+This plugin can provide dramatic performance boosts and is an ideal solution for sites with many pages and predominantly static content.
 
 | NOTE: Grav Debugger will not display when the page is cached
 
@@ -34,14 +34,16 @@ The default configuration provided in the `user/plugins/advanced-pagecache.yaml`
 enabled: true                       # set to false to disable this plugin completely
 disabled_with_params: true          # disabled if there are params set on this URI (eg. /color:blue)
 disabled_with_query: true           # disabled if there are query options set on this URI (eg. ?color=blue)
+disabled_on_login: true             # disabled if a user is logged in on the frontend of the site
+per_user_caching: false             # enable per-user caching of pages (if not disabled_on_login)
 disabled_extensions: [rss,xml,json] # disabled for these extensions
 whitelist:                          # set to array of enabled page paths to enable only when in whitelist
   - /cache-this-page
 blacklist:                          # set to array and provide list of page paths to disable plugin for
   - /error
+  - /login
   - /random
   - /dont-cache-this-page
-  - /error
 ```
 
 If a **whitelist** array is provided, **only** pages specifically listed will be cached. Language prefixes are ignored, but URL extensions are taken into account.

--- a/advanced-pagecache.php
+++ b/advanced-pagecache.php
@@ -21,20 +21,20 @@ class AdvancedPageCachePlugin extends Plugin
     }
 
     /**
-     * Return `true` if the page has no extension, or has the default page extension. 
+     * Return `true` if the page has no extension, or has the default page extension.
      * Return `false` if for example is a RSS version of the page
      */
     private function isValidExtension() {
         /** @var Uri $uri */
         $uri = $this->grav['uri'];
         $extension = $uri->extension();
-        
+
         if (!$extension) {
             return true;
         }
 
         $disabled_extensions = $this->grav['config']->get('plugins.advanced-pagecache.disabled_extensions');
-        
+
         if (in_array($extension, (array) $disabled_extensions)) {
             return false;
         }
@@ -55,6 +55,7 @@ class AdvancedPageCachePlugin extends Plugin
         $route = str_replace($uri->baseIncludingLanguage(), '', $full_route);
         $params = $uri->params(null, true);
         $query = $uri->query(null, true);
+        $user = $this->grav["user"];
         $lang = $this->grav['language']->getLanguageURLPrefix();
 
         // Definitely don't run in admin plugin or is not a valid extension
@@ -67,6 +68,7 @@ class AdvancedPageCachePlugin extends Plugin
             // do not run in these scenarios
             if ($config['disabled_with_params'] && !empty($params) ||
                 $config['disabled_with_query'] && !empty($query) ||
+                $config['disabled_on_login'] && $user["authenticated"] ||
                 in_array($route, (array)$config['blacklist'])) {
                 return;
             }

--- a/advanced-pagecache.php
+++ b/advanced-pagecache.php
@@ -74,7 +74,11 @@ class AdvancedPageCachePlugin extends Plugin
             }
         }
 
-        $this->pagecache_key = md5('adv-pc-' . $lang . $full_route);
+        if ($config['per_user_caching']) {
+            $this->pagecache_key = md5('adv-pc-' . $lang . $full_route . $user["username"]);
+        } else {
+            $this->pagecache_key = md5('adv-pc-' . $lang . $full_route);
+        }
 
         // Should run and store page
         $this->enable([

--- a/advanced-pagecache.yaml
+++ b/advanced-pagecache.yaml
@@ -1,6 +1,7 @@
 enabled: true                       # set to false to disable this plugin completely
 disabled_with_params: true          # disabled if there are params set on this URI (eg. /color:blue)
 disabled_with_query: true           # disabled if there are query options set on this URI (eg. ?color=blue)
+disabled_on_login: true             # disabled if a user is logged in on the frontend of the site
 disabled_extensions: [rss,xml,json] # disabled for these extensions
 whitelist:                          # set to array of enabled page paths to enable only when in whitelist
   - /cache-this-page

--- a/advanced-pagecache.yaml
+++ b/advanced-pagecache.yaml
@@ -2,10 +2,12 @@ enabled: true                       # set to false to disable this plugin comple
 disabled_with_params: true          # disabled if there are params set on this URI (eg. /color:blue)
 disabled_with_query: true           # disabled if there are query options set on this URI (eg. ?color=blue)
 disabled_on_login: true             # disabled if a user is logged in on the frontend of the site
+per_user_caching: false             # enable per-user caching of pages (if not disabled_on_login)
 disabled_extensions: [rss,xml,json] # disabled for these extensions
 whitelist:                          # set to array of enabled page paths to enable only when in whitelist
   - /cache-this-page
 blacklist:                          # set to array and provide list of page paths to disable plugin for
   - /error
+  - /login
   - /random
   - /dont-cache-this-page

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -62,6 +62,18 @@ form:
         type: bool
       help: Disable caching if the user is logged in
 
+    per_user_caching:
+      type: toggle
+      label: Per-user caching
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+      help: Enable per-user caching for logged in users (if caching is not disabled for logged in users)
+
     disabled_extensions:
       type: selectize
       size: large

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -50,6 +50,18 @@ form:
         type: bool
       help: Enable if there are query options set on this URI (eg. ?color=blue)
 
+    disabled_on_login:
+      type: toggle
+      label: Disabled for logged in users
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+      help: Disable caching if the user is logged in
+
     disabled_extensions:
       type: selectize
       size: large


### PR DESCRIPTION
This PR introduces two new configuration options:

## Disable caching for logged in users
- Useful if content is normally static, but there's dynamic content or different content when logged in.
- Defaults is `true`, because sites with logins would probably want this enabled and everyone else shouldn't be affected.

## Enable per-user caching
- As above, but with per-user differences in content that you would like to have statically cached.
- Acts as an alternative to disabling the cache, with disabling taking precedence.
- Defaults is `false`, because cache space could be limited and/or logins infrequent, plus there could be issues with large numbers of users.